### PR TITLE
docs: add project code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,108 @@
+# Contributor Covenant Code of Conduct
+
+This project follows a Code of Conduct adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+## Our Pledge
+
+We pledge to make participation in the mcp-geo community welcoming, safe, equitable, and respectful for everyone.
+
+We value the dignity, rights, perspectives, and contributions of all participants. Participation is open on equal terms to people acting in good faith, regardless of identity, background, experience, disability, age, race, ethnicity, caste, nationality, religion or philosophy, sex, gender, gender identity or expression, sexual orientation, language, socioeconomic status, education, neurodiversity, physical characteristics, or other status.
+
+## Encouraged Behaviors
+
+Community members are expected to communicate thoughtfully and professionally, recognizing that language, culture, and experience can affect how words and actions are understood.
+
+Positive participation includes:
+
+1. Respecting the purpose of the project and its community spaces.
+2. Communicating honestly, constructively, and with consideration for others.
+3. Respecting different technical viewpoints, backgrounds, and experiences.
+4. Taking responsibility for your actions, code, documentation, and other contributions.
+5. Giving and receiving constructive feedback in good faith.
+6. Acknowledging harm or mistakes and making a reasonable effort to repair them.
+7. Helping maintain a collaborative environment in which people can participate safely.
+
+## Restricted Behaviors
+
+The following conduct is not acceptable. Threatening, encouraging, or promoting these behaviors is also a violation of this Code of Conduct.
+
+1. **Harassment.** Ignoring clearly stated boundaries, targeted intimidation, stalking, or continuing unwanted personal attention after being asked to stop.
+2. **Personal attacks.** Insults, degrading remarks, hostile ridicule, or comments aimed at demeaning an individual or group rather than addressing the work.
+3. **Discrimination or stereotyping.** Treating people adversely or making assumptions about their character or ability because of identity or protected characteristics.
+4. **Sexualization.** Sexual attention, imagery, language, advances, or other intimate behavior that is inappropriate to the project or community context.
+5. **Violating privacy or confidentiality.** Publishing, soliciting, or acting on another person's private, confidential, or identifying information without permission.
+6. **Endangerment.** Threatening, encouraging, or causing violence, self-harm, or other physical or material harm toward a person or group.
+7. **Other harmful conduct.** Behavior that materially undermines the safety, dignity, or ability of others to participate in the community.
+
+### Other Restrictions
+
+The project also prohibits:
+
+1. **Misleading identity.** Impersonating another person or misrepresenting identity to evade moderation or enforcement.
+2. **Uncredited material.** Presenting another person's work as your own or knowingly failing to provide required attribution.
+3. **Abusive promotion.** Posting commercial, promotional, or repetitive material outside the norms and purpose of the project community.
+4. **Irresponsible publication.** Sharing harmful or restricted material without appropriate context, safeguards, or a legitimate project purpose.
+
+## Reporting an Issue
+
+Not every disagreement is a Code of Conduct violation. When a possible violation does occur, report it promptly and privately so it can be assessed without unnecessarily exposing the people involved.
+
+To report a possible violation, use the private email contact published on the [DigestSEO contact page](https://digestseo.com/contact/). Use the subject **`mcp-geo Code of Conduct report`** and include enough information to evaluate the report, such as relevant links, dates, context, and screenshots where appropriate. **Do not open a public GitHub issue or discussion for a conduct report.** Do not include credentials, access tokens, or unrelated private data.
+
+The project maintainer acts as the Community Moderator for mcp-geo. Reports will be reviewed as promptly as reasonably possible. The identity of reporters, witnesses, and affected people, as well as report contents and enforcement details, will be kept confidential to the extent reasonably possible while still allowing a fair investigation and necessary safety actions.
+
+If a report concerns the project maintainer, or you are not comfortable using the project reporting route, use [GitHub's abuse-reporting tools](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) for conduct or content on GitHub. For conduct occurring on another platform or at an event, use that platform's or event organizer's independent reporting mechanism where available.
+
+The Community Moderator may review relevant repository content, messages, logs, screenshots, and other evidence, and may ask involved people or witnesses for additional context. Enforcement decisions will be made privately whenever possible. A public moderation notice may be issued when necessary to protect the community, correct the public record, or explain a restriction without disclosing unnecessary personal information.
+
+## Addressing and Repairing Harm
+
+When a violation is substantiated, the Community Moderator will choose a response proportionate to the severity, impact, pattern of behavior, and risk of recurrence. More serious incidents may skip earlier steps.
+
+### 1. Warning
+
+**When it may apply:** A limited first incident or a lower-impact violation.
+
+**Consequence:** A private written warning explaining the behavior that must stop and the expected standard going forward.
+
+**Repair:** Depending on the situation, repair may include acknowledging responsibility, clarifying expectations, correcting harmful material, or offering an appropriate private apology.
+
+### 2. Temporarily Limited Activities
+
+**When it may apply:** Repeated behavior after a warning, or a more serious first incident.
+
+**Consequence:** A defined cooling-off period or temporary limitation on specific interactions, project spaces, or activities.
+
+**Repair:** The participant is expected to respect the restriction, reflect on impact, complete any stated corrective action, and return without repeating the behavior.
+
+### 3. Temporary Suspension
+
+**When it may apply:** A pattern of serious or repeated violations, or a single substantial violation that makes continued participation unsafe during review or remediation.
+
+**Consequence:** Temporary removal from project community spaces or participation channels, with conditions for return where appropriate.
+
+**Repair:** Any return may require compliance with stated conditions, demonstrated respect for affected participants and project boundaries, and a credible commitment to changed behavior.
+
+### 4. Permanent Ban
+
+**When it may apply:** Severe conduct, threats to community safety, or repeated violations that previous interventions have not resolved.
+
+**Consequence:** Removal from project-managed community spaces and communication channels to the extent available to project maintainers. Contributions or interactions may be blocked or rejected where the platform permits.
+
+**Repair:** A permanent ban is reserved for situations where continued participation cannot be reconciled with community safety. No reinstatement is guaranteed.
+
+This enforcement ladder is a guideline rather than a rigid formula. The Community Moderator may use reasonable discretion to protect participants, preserve evidence, comply with platform rules or law, and select an action proportionate to the circumstances.
+
+## Scope
+
+This Code of Conduct applies in project-managed community spaces, including repository issues, pull requests, discussions, reviews, comments, and other project communication channels. It also applies when someone is officially representing mcp-geo or its community in public, including through an official account, an official project communication channel, or as an appointed representative at an online or in-person event.
+
+This Code of Conduct does not replace the rules, terms, or safety processes of GitHub or any other platform on which project activity occurs. Platform operators may take independent action under their own policies.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the [Organization for Ethical Source](https://ethicalsource.dev/) and is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Contributor Covenant resources, including its [FAQ](https://www.contributor-covenant.org/faq/), [translations](https://www.contributor-covenant.org/translations/), and [enforcement resources](https://www.contributor-covenant.org/resources/), are available from the Contributor Covenant project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for being here. PRs and issues both welcome.
 
+By participating in this project, you agree to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Adds a root-level Contributor Covenant 3.0-based Code of Conduct and a single discoverability link from CONTRIBUTING.md.

Scope is intentionally limited to OSS governance/readiness. No runtime, package, deployment, Vercel sponsorship, or product behavior changes.

Reporting uses the existing private contact route published on the DigestSEO contact page, with GitHub's abuse-reporting flow as an independent fallback for GitHub-hosted conduct.