### PR TITLE
feat: add fixed-price AI visibility audit

### DIFF
--- a/MONETIZATION_EXPERIMENT.md
+++ b/MONETIZATION_EXPERIMENT.md
@@ -1,0 +1,95 @@
+# mcp-geo Monetization Experiment
+
+## Experiment contract
+
+- Start date: 2026-09-10 (Europe/Ljubljana)
+- Starting main SHA: `f48c265fdac3e8aa5881564b9b10b2158e0bec71`
+- Fixed end: 2026-09-17 04:05 Europe/Ljubljana
+- Status: RUNNING
+- Revenue status: UNVERIFIED
+
+## Frozen hypothesis
+
+Sell a fixed-price **EUR 99 one-time AI Visibility Audit** to indie SaaS founders and small marketing/SEO teams that want a credible multi-engine GEO baseline and prioritized next actions without subscribing to another recurring dashboard or operating mcp-geo themselves.
+
+The free/open-source mcp-geo product remains unchanged in availability and capability. The paid value is the human-operated setup, execution, interpretation, and concise client-ready result.
+
+## Frozen target paying user
+
+A founder, marketer, or small SEO/GEO team responsible for one active brand who wants to answer: where does the brand appear in AI answers, which competitors win the same buyer-intent prompts, what sources/citations appear, and what should be addressed first?
+
+## Frozen offer and value exchange
+
+**mcp-geo AI Visibility Audit - EUR 99 one time**
+
+Scope:
+
+- one brand/domain;
+- up to three named competitors;
+- 20 buyer-intent prompts generated or agreed for the brand/category;
+- checks across up to five mcp-geo-supported AI surfaces where the configured providers return usable results;
+- brand visibility/share-of-voice comparison;
+- citation/source evidence where returned by the engines;
+- prioritized content-gap/action memo grounded in the observed prompt results;
+- concise delivered report;
+- target delivery within two business days after usable brand/competitor input is received.
+
+No ranking improvement, citation gain, traffic increase, or commercial outcome is guaranteed.
+
+## Monetization/payment path
+
+Public request path: `info@tomiseregi.si` with an mcp-geo audit request. The buyer receives normal invoice/payment instructions after fit and scope are confirmed. A request, invoice, or promise does **not** count as revenue; only independently verified money actually received/earned counts.
+
+GitHub Sponsors is not part of the frozen offer and must not be treated as active unless its public profile/payment capability is independently verified.
+
+## Evidence for the choice
+
+Retrieved 2026-09-10 unless otherwise stated.
+
+1. mcp-geo already implements the required measurement primitives: AI visibility snapshots, competitor comparison, citation evidence, content-gap recommendations, and up to five supported AI engines. Its README also shows an example strategist-style report and a public hosted endpoint. Source: https://github.com/AKzar1el/mcp-geo
+2. The repository currently has 44 GitHub stars, indicating some existing public interest without implying paying demand. Source: https://api.github.com/repos/AKzar1el/mcp-geo
+3. Peec AI's official pricing positions recurring AI-search visibility software at a materially higher recurring spend: its current Starter plan includes 50 prompts, 3 models, and one project; its published AI instructions list the Starter price as USD 95/month. Sources: https://peec.ai/pricing and https://peec.ai/ai-instructions
+4. A current GEO audit provider sells a directly comparable one-time diagnostic from USD 99, including prompt-level visibility testing, competitor share-of-voice, and quick-win actions. Source: https://generativeengineoptimization.solutions/geo-audit/
+5. GenSight publishes a USD 99 one-time AI visibility audit alongside higher recurring subscriptions, supporting a one-off diagnostic as a real category purchase pattern. Source: https://gensight.ai/
+6. Recent public buyer/community discussions show both demand for actionable AI-visibility insight and resistance to expensive recurring tool stacks. Examples: https://www.reddit.com/r/SEO_for_AI/comments/1vq9raq/looking_for_the_best_basic_ai_seo_tool/ and https://www.reddit.com/r/b2bmarketing/comments/1sm9qcd/what_is_the_best_free_ai_visibility_tool/
+7. Recent community discussion also criticizes AI-visibility tools that provide inconsistent scores or dashboards without clear causal/actionable interpretation. This favors selling a bounded interpreted diagnostic rather than another dashboard subscription. Example: https://www.reddit.com/r/SEO_tools_reviews/comments/1t683c8/removed/
+
+## Why this hypothesis won
+
+Compared with sponsorship-only, a paid hosted SaaS tier, affiliate monetization, and a custom consulting retainer, the fixed-price audit has the shortest credible path to a monetary event within seven days while reusing capabilities already shipped in mcp-geo. It requires no new billing platform, no new external account, no unrelated repository, no recurring service architecture, and no degradation of the OSS product.
+
+The EUR 99 price is intentionally aligned with current one-time category audits rather than invented from internal cost. It is high enough to represent a real purchase but low enough to be a bounded diagnostic rather than a consulting engagement.
+
+## Success and failure
+
+**SUCCESS:** at least one independently verifiable, attributable monetary event greater than EUR 0 caused by this frozen mcp-geo audit offer before the fixed end time.
+
+**FAIL:** no such verified monetary event by 2026-09-17 04:05 Europe/Ljubljana.
+
+**UNVERIFIED:** credible evidence suggests a payment may have occurred, but independent confirmation is unavailable by the fixed end time.
+
+## Diagnostic metrics that do not count as success
+
+- GitHub stars/forks/watchers;
+- README/audit-page visits if observable without adding hidden telemetry;
+- clicks;
+- emails or audit inquiries;
+- invoices issued;
+- waitlist joins;
+- repository traffic;
+- report requests;
+- verbal/written intent to buy;
+- projected or pipeline revenue.
+
+## Frozen fields
+
+The following may not change during this experiment:
+
+- monetization hypothesis: fixed-price one-time AI Visibility Audit;
+- target paying user: indie SaaS founders and small marketing/SEO teams responsible for one active brand;
+- offer category/value exchange: EUR 99 for setup/execution/interpretation of a bounded mcp-geo audit, with the OSS product remaining free;
+- success criterion;
+- failure criterion;
+- fixed end date/time.
+
+Implementation details, exact wording, placement, and reliability fixes may change only when evidence supports them and only within this frozen offer.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Engineering case study: [DigestSEO MCP Suite — AI visibility, Search Console, 
 
 > **Prefer zero setup?** Try the hosted version at [digestseo.com](https://digestseo.com) — managed Cloudflare infra, no API keys to manage, multi-brand, scheduled refresh, web UI. Waitlist now open. [Join waitlist →](https://digestseo.com/#waitlist)
 
+> **Need a client-ready baseline without running the stack yourself?** The [mcp-geo AI Visibility Audit](https://geo-mcp.digestseo.com/audit) is EUR 99 one time: one brand, up to three competitors, 20 buyer-intent prompts, checks across up to five supported AI surfaces where configured providers return usable results, citation evidence, and a prioritized action memo. The open-source package remains free.
+
 ---
 
 ## What it produces

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from './engines.js';
 import { seedBrand, type SeedBrandInput } from './core/seed.js';
 import { DomainInputError } from './core/domain.js';
+import { handlePublicAudit } from './public-audit.js';
 
 export interface Env {
   OAUTH_KV: KVNamespace;
@@ -562,6 +563,9 @@ const defaultHandler = {
     ctx: ExecutionContext,
   ): Promise<Response> {
     const url = new URL(request.url);
+
+    const auditResponse = handlePublicAudit(request);
+    if (auditResponse) return auditResponse;
 
     if (url.pathname === '/') {
       if (request.method !== 'GET') {

--- a/src/public-audit.ts
+++ b/src/public-audit.ts
@@ -1,0 +1,76 @@
+const AUDIT_EMAIL = 'info@tomiseregi.si';
+const AUDIT_SUBJECT = 'mcp-geo AI Visibility Audit';
+
+function auditHtml(origin: string): string {
+  const mailto = `mailto:${AUDIT_EMAIL}?subject=${encodeURIComponent(AUDIT_SUBJECT)}`;
+  const mcpUrl = `${origin}/mcp`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>mcp-geo AI Visibility Audit - EUR 99</title>
+  <meta name="description" content="A one-time AI Visibility Audit using mcp-geo: 20 buyer-intent prompts, competitor comparison, citation evidence, and prioritized next actions.">
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #0b0d10; color: #f4f6f8; }
+    main { width: min(760px, calc(100% - 40px)); margin: 0 auto; padding: 72px 0 88px; }
+    .eyebrow { margin: 0 0 16px; color: #9ba7b4; font-size: 13px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+    h1 { margin: 0; max-width: 700px; font-size: clamp(40px, 8vw, 72px); line-height: .98; letter-spacing: -.05em; }
+    .lede { max-width: 650px; margin: 24px 0 0; color: #c4ccd4; font-size: 20px; line-height: 1.55; }
+    .price { margin: 42px 0 8px; font-size: 34px; font-weight: 800; letter-spacing: -.03em; }
+    .price span { color: #9ba7b4; font-size: 16px; font-weight: 500; letter-spacing: 0; }
+    ul { display: grid; gap: 12px; margin: 28px 0 36px; padding: 0; list-style: none; }
+    li { padding: 14px 0; border-bottom: 1px solid #252a31; color: #dce2e8; line-height: 1.45; }
+    .cta { display: inline-block; padding: 14px 20px; border-radius: 8px; background: #f4f6f8; color: #0b0d10; font-weight: 800; text-decoration: none; }
+    .fine { margin-top: 18px; color: #929daa; font-size: 14px; line-height: 1.6; }
+    .oss { margin-top: 56px; padding-top: 24px; border-top: 1px solid #252a31; color: #aeb8c2; line-height: 1.65; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">mcp-geo / fixed-price diagnostic</p>
+    <h1>One-time AI Visibility Audit</h1>
+    <p class="lede">A focused baseline for founders and small marketing teams who want to see where their brand appears in AI answers, which competitors win the same buyer-intent prompts, and what to address first.</p>
+
+    <p class="price">EUR 99 <span>/ one time</span></p>
+    <ul>
+      <li>One brand/domain and up to three competitors.</li>
+      <li>20 buyer-intent prompts tailored to the brand and category.</li>
+      <li>Checks across up to five mcp-geo-supported AI surfaces where configured providers return usable results.</li>
+      <li>Visibility/share-of-voice comparison plus citation and source evidence where returned.</li>
+      <li>A prioritized content-gap and action memo grounded in the observed prompt results.</li>
+      <li>Target delivery within two business days after usable brand and competitor input is received.</li>
+    </ul>
+
+    <a class="cta" href="${mailto}">Request the EUR 99 audit</a>
+    <p class="fine">Email ${AUDIT_EMAIL}. No subscription, no sales call required. The audit does not guarantee rankings, citations, traffic, or commercial outcomes.</p>
+
+    <p class="oss">Prefer to run it yourself? <strong>mcp-geo remains free and open-source under MIT.</strong> Use the local npm package or connect to the MCP endpoint at <a href="${mcpUrl}">${mcpUrl}</a>. Source and setup instructions are on <a href="https://github.com/AKzar1el/mcp-geo">GitHub</a>.</p>
+  </main>
+</body>
+</html>`;
+}
+
+export function handlePublicAudit(request: Request): Response | null {
+  const url = new URL(request.url);
+  if (url.pathname !== '/audit') return null;
+
+  if (request.method !== 'GET') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { Allow: 'GET' },
+    });
+  }
+
+  return new Response(auditHtml(url.origin), {
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'text/html; charset=utf-8',
+      'x-content-type-options': 'nosniff',
+    },
+  });
+}

--- a/tests/unit/public-audit.test.ts
+++ b/tests/unit/public-audit.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+async function loadAuditModule() {
+  try {
+    return await import('../../src/public-audit');
+  } catch (error) {
+    assert.fail(`public audit module is not implemented: ${String(error)}`);
+  }
+}
+
+test('GET /audit serves the frozen EUR 99 audit offer', async () => {
+  const { handlePublicAudit } = await loadAuditModule();
+  const response = handlePublicAudit(
+    new Request('https://geo-mcp.digestseo.com/audit'),
+  );
+
+  assert.ok(response);
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') ?? '', /text\/html/);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+
+  const body = await response.text();
+  assert.match(body, /EUR 99/);
+  assert.match(body, /one-time AI Visibility Audit/i);
+  assert.match(body, /up to three competitors/i);
+  assert.match(body, /20 buyer-intent prompts/i);
+  assert.match(body, /up to five/i);
+  assert.match(body, /info@tomiseregi\.si/);
+  assert.match(body, /open-source/i);
+  assert.doesNotMatch(body, /guaranteed (?:rank|traffic|citation)/i);
+  assert.doesNotMatch(body, /GitHub Sponsors is active/i);
+});
+
+test('non-GET /audit requests are rejected without entering MCP or admin flows', async () => {
+  const { handlePublicAudit } = await loadAuditModule();
+  const response = handlePublicAudit(
+    new Request('https://geo-mcp.digestseo.com/audit', { method: 'POST' }),
+  );
+
+  assert.ok(response);
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get('allow'), 'GET');
+});
+
+test('non-audit paths are ignored by the public audit router', async () => {
+  const { handlePublicAudit } = await loadAuditModule();
+  const response = handlePublicAudit(
+    new Request('https://geo-mcp.digestseo.com/healthz'),
+  );
+
+  assert.equal(response, null);
+});


### PR DESCRIPTION
Adds one bounded monetization path without changing the free OSS product.

- freezes a EUR 99 one-time mcp-geo audit experiment
- adds a stateless `GET /audit` page and README CTA
- leaves MCP/OAuth/admin/storage behavior and dependencies unchanged

Verification: `npm ci`, `npm run typecheck`, `npm run test:unit` (66 passing), `npm run build`, `npm run test:stdio` (2 passing).