### PR TITLE
fix: keep audit request path actionable

### DIFF
--- a/MONETIZATION_EXPERIMENT.md
+++ b/MONETIZATION_EXPERIMENT.md
@@ -93,3 +93,12 @@ The following may not change during this experiment:
 - fixed end date/time.
 
 Implementation details, exact wording, placement, and reliability fixes may change only when evidence supports them and only within this frozen offer.
+
+## Operational log
+
+### 2026-09-10
+
+- PR #25 merged the frozen experiment contract and tested `/audit` Worker surface into `main`; main CI passed.
+- A production Wrangler dry-run against the existing `digestseo-mcp` topology passed with the expected D1, KV, Durable Object, service, and `SELF_URL` bindings.
+- The real deploy was rejected before a new Worker version was created because the machine's current `CLOUDFLARE_API_TOKEN` lacks `Workers Scripts Write`. The previous production version remains the last-known-good deployment.
+- Because `https://geo-mcp.digestseo.com/audit` therefore remains undeployed, the public README audit CTA was changed to the already-frozen direct `mailto:info@tomiseregi.si` request path instead of leaving a broken conversion link. This is an implementation fallback inside the same frozen EUR 99 audit hypothesis, not a pivot.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Engineering case study: [DigestSEO MCP Suite — AI visibility, Search Console, 
 
 > **Prefer zero setup?** Try the hosted version at [digestseo.com](https://digestseo.com) — managed Cloudflare infra, no API keys to manage, multi-brand, scheduled refresh, web UI. Waitlist now open. [Join waitlist →](https://digestseo.com/#waitlist)
 
-> **Need a client-ready baseline without running the stack yourself?** The [mcp-geo AI Visibility Audit](https://geo-mcp.digestseo.com/audit) is EUR 99 one time: one brand, up to three competitors, 20 buyer-intent prompts, checks across up to five supported AI surfaces where configured providers return usable results, citation evidence, and a prioritized action memo. The open-source package remains free.
+> **Need a client-ready baseline without running the stack yourself?** The [mcp-geo AI Visibility Audit](mailto:info@tomiseregi.si?subject=mcp-geo%20AI%20Visibility%20Audit) is EUR 99 one time: one brand, up to three competitors, 20 buyer-intent prompts, checks across up to five supported AI surfaces where configured providers return usable results, citation evidence, and a prioritized action memo. The open-source package remains free.
 
 ---
 

--- a/tests/unit/revenue-readme.test.ts
+++ b/tests/unit/revenue-readme.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const readme = readFileSync('README.md', 'utf8');
+
+test('README audit CTA remains actionable when Worker deployment is unavailable', () => {
+  assert.match(
+    readme,
+    /\[mcp-geo AI Visibility Audit\]\(mailto:info@tomiseregi\.si\?subject=mcp-geo%20AI%20Visibility%20Audit\)/,
+  );
+  assert.doesNotMatch(
+    readme,
+    /\[mcp-geo AI Visibility Audit\]\(https:\/\/geo-mcp\.digestseo\.com\/audit\)/,
+  );
+});


### PR DESCRIPTION
Keeps the frozen EUR 99 audit offer publicly actionable after the production Worker deploy was blocked by the current Cloudflare token permissions.

- changes the README audit CTA from the currently undeployed `/audit` route to the frozen direct email request path
- records the deployment blocker and fallback in the experiment log
- adds a regression test so the README cannot point at the unavailable route

The `/audit` Worker implementation remains on main for a later authorized deployment. No monetization hypothesis, price, customer, product capability, dependency, binding, or storage behavior changes.

Verification: typecheck; 67 unit tests; build; 2 stdio smoke tests.