### PR TITLE
Prefill attributable audit requests

### DIFF
--- a/src/public-audit.ts
+++ b/src/public-audit.ts
@@ -1,8 +1,17 @@
 const AUDIT_EMAIL = 'info@tomiseregi.si';
-const AUDIT_SUBJECT = 'mcp-geo AI Visibility Audit';
+const AUDIT_SUBJECT = 'mcp-geo AI Visibility Audit - EUR 99';
+const AUDIT_BODY = `Hi Tomi,
+
+I'd like the EUR 99 mcp-geo AI Visibility Audit.
+
+Brand/domain:
+Competitors (up to 3):
+Context or priority (optional):
+
+Source: mcp-geo audit page`;
 
 function auditHtml(origin: string): string {
-  const mailto = `mailto:${AUDIT_EMAIL}?subject=${encodeURIComponent(AUDIT_SUBJECT)}`;
+  const mailto = `mailto:${AUDIT_EMAIL}?subject=${encodeURIComponent(AUDIT_SUBJECT)}&body=${encodeURIComponent(AUDIT_BODY)}`;
   const mcpUrl = `${origin}/mcp`;
 
   return `<!doctype html>

--- a/tests/unit/public-audit.test.ts
+++ b/tests/unit/public-audit.test.ts
@@ -32,6 +32,29 @@ test('GET /audit serves the frozen EUR 99 audit offer', async () => {
   assert.doesNotMatch(body, /GitHub Sponsors is active/i);
 });
 
+test('audit CTA opens a prefilled attributable request email', async () => {
+  const { handlePublicAudit } = await loadAuditModule();
+  const response = handlePublicAudit(
+    new Request('https://geo-mcp.digestseo.com/audit'),
+  );
+
+  assert.ok(response);
+  const body = await response.text();
+  const href = body.match(/<a class=\"cta\" href=\"([^\"]+)\"/)?.[1];
+  assert.ok(href);
+
+  const mailto = new URL(href);
+  assert.equal(mailto.protocol, 'mailto:');
+  assert.equal(mailto.pathname, 'info@tomiseregi.si');
+  assert.equal(
+    mailto.searchParams.get('subject'),
+    'mcp-geo AI Visibility Audit - EUR 99',
+  );
+  assert.match(mailto.searchParams.get('body') ?? '', /Brand\/domain:/);
+  assert.match(mailto.searchParams.get('body') ?? '', /Competitors \(up to 3\):/);
+  assert.match(mailto.searchParams.get('body') ?? '', /Source: mcp-geo audit page/);
+});
+
 test('non-GET /audit requests are rejected without entering MCP or admin flows', async () => {
   const { handlePublicAudit } = await loadAuditModule();
   const response = handlePublicAudit(


### PR DESCRIPTION
Reduces friction on the existing EUR 99 AI Visibility Audit by prefilling the request email with brand/domain, competitors, optional context, and a deterministic source marker. No telemetry or offer changes. Local qualification: typecheck, 68 unit assertions, build, and 2 stdio smokes passed.