### PR TITLE
Use npm trusted publishing OIDC

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -19,6 +19,7 @@ on:
       - .github/workflows/publish-mcp.yml
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -55,15 +56,18 @@ jobs:
         run: ./mcp-publisher validate server.json
 
   publish-npm:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
 
@@ -73,8 +77,6 @@ jobs:
       # prepublishOnly runs typecheck + unit tests + build before the tarball is created.
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   check-npm-version:
     if: github.event_name == 'push'
@@ -107,7 +109,7 @@ jobs:
     if: >-
       always() &&
       needs.validate.result == 'success' &&
-      ((github.event_name == 'release' && needs.publish-npm.result == 'success') ||
+      (((github.event_name == 'release' || github.event_name == 'workflow_dispatch') && needs.publish-npm.result == 'success') ||
        (github.event_name == 'push' && needs.check-npm-version.outputs.published == 'true'))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Switch the npm publish job from a missing long-lived NPM_TOKEN to npm Trusted Publishing via GitHub OIDC. Adds a manual recovery trigger so the existing 0.3.3 package can be published from current main after the npm package trust relationship is registered. Node 24 is used for the publish job to satisfy npm OIDC requirements. No package code or product behavior changes.