### PR TITLE
docs: surface audit in badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![MCP](https://img.shields.io/badge/MCP-Server-blueviolet)](https://modelcontextprotocol.io/)
 [![mcp-geo MCP server](https://glama.ai/mcp/servers/AKzar1el/mcp-geo/badges/score.svg)](https://glama.ai/mcp/servers/AKzar1el/mcp-geo)
 [![GitHub stars](https://img.shields.io/github/stars/AKzar1el/mcp-geo?style=social)](https://github.com/AKzar1el/mcp-geo/stargazers)
+[![EUR 99 AI Visibility Audit](https://img.shields.io/badge/AI_Visibility_Audit-EUR_99-2ea44f)](https://geo-mcp.digestseo.com/audit)
 
 
 ## Quick Install

--- a/tests/unit/revenue-readme.test.ts
+++ b/tests/unit/revenue-readme.test.ts
@@ -7,6 +7,11 @@ const readme = readFileSync('README.md', 'utf8');
 test('README exposes audit details and an attributable direct request path', () => {
   assert.match(
     readme,
+    /\[!\[EUR 99 AI Visibility Audit\]\(https:\/\/img\.shields\.io\/badge\/AI_Visibility_Audit-EUR_99-[^)]+\)\]\(https:\/\/geo-mcp\.digestseo\.com\/audit\)/,
+  );
+
+  assert.match(
+    readme,
     /\[mcp-geo AI Visibility Audit\]\(https:\/\/geo-mcp\.digestseo\.com\/audit\)/,
   );
   assert.match(
@@ -16,6 +21,11 @@ test('README exposes audit details and an attributable direct request path', () 
 
   const auditCta = readme.indexOf('> **Need a client-ready baseline without running the stack yourself?**');
   const waitlistCta = readme.indexOf('> **Prefer zero setup?**');
+  const auditBadge = readme.indexOf('[![EUR 99 AI Visibility Audit]');
+  const quickInstall = readme.indexOf('## Quick Install');
+  assert.ok(auditBadge >= 0);
+  assert.ok(quickInstall >= 0);
+  assert.ok(auditBadge < quickInstall, 'paid audit badge should stay in the opening badge row');
   assert.ok(auditCta >= 0);
   assert.ok(waitlistCta >= 0);
   assert.ok(auditCta < waitlistCta, 'paid audit CTA should appear before the non-revenue waitlist CTA');


### PR DESCRIPTION
Surfaces the existing EUR 99 AI Visibility Audit in the README badge row, linking to the live audit page. Keeps the offer and OSS product unchanged and adds a regression check that the badge remains above Quick Install.\n\nQualification: typecheck, 70/70 unit assertions, build, stdio 2/2.