### PR TITLE
docs: clarify audit proof and payment handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ Engineering case study: [DigestSEO MCP Suite — AI visibility, Search Console, 
 
 > **Need a client-ready baseline without running the stack yourself?** The [mcp-geo AI Visibility Audit](https://geo-mcp.digestseo.com/audit) is EUR 99 one time: one brand, up to three competitors, 20 buyer-intent prompts, checks across up to five supported AI surfaces where configured providers return usable results, citation evidence, and a prioritized action memo. The open-source package remains free.
 >
+> **See proof first:** [Open the sample report](docs/demo-report-full.png) generated through mcp-geo to see the output style and evidence depth before requesting the audit.
+>
 > **Ready to request it?** [Open a prefilled email](mailto:info@tomiseregi.si?subject=mcp-geo%20AI%20Visibility%20Audit%20-%20EUR%2099&body=Hi%20Tomi%2C%0A%0AI%27d%20like%20the%20EUR%2099%20mcp-geo%20AI%20Visibility%20Audit.%0A%0ABrand%2Fdomain%3A%0ACompetitors%20%28up%20to%203%29%3A%0AContext%20or%20priority%20%28optional%29%3A%0A%0ASource%3A%20mcp-geo%20README) with your brand/domain and up to three competitors. No subscription or sales call is required.
+>
+> **Payment handoff:** After fit and scope are confirmed, I reply with the normal invoice/payment instructions.
 
 > **Prefer zero setup?** Try the hosted version at [digestseo.com](https://digestseo.com) — managed Cloudflare infra, no API keys to manage, multi-brand, scheduled refresh, web UI. Waitlist now open. [Join waitlist →](https://digestseo.com/#waitlist)
 

--- a/tests/unit/revenue-readme.test.ts
+++ b/tests/unit/revenue-readme.test.ts
@@ -18,6 +18,14 @@ test('README exposes audit details and an attributable direct request path', () 
     readme,
     /mailto:info@tomiseregi\.si\?subject=mcp-geo%20AI%20Visibility%20Audit%20-%20EUR%2099&body=[^\s)]*Source%3A%20mcp-geo%20README/,
   );
+  assert.match(
+    readme,
+    /> \*\*See proof first:\*\* \[Open the sample report\]\(docs\/demo-report-full\.png\)/,
+  );
+  assert.match(
+    readme,
+    /> \*\*Payment handoff:\*\* After fit and scope are confirmed, I reply with the normal invoice\/payment instructions\./,
+  );
 
   const auditCta = readme.indexOf('> **Need a client-ready baseline without running the stack yourself?**');
   const waitlistCta = readme.indexOf('> **Prefer zero setup?**');


### PR DESCRIPTION
Surfaces the existing sample report directly in the paid-audit CTA and makes the existing invoice/payment handoff explicit.\n\nValidation:\n- targeted README revenue test red before copy change, green after\n- npm run typecheck\n- npm run test:unit (72/72)\n- npm run build\n- npm run test:stdio (2/2)