### PR TITLE
docs: publish audit methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Engineering case study: [DigestSEO MCP Suite — AI visibility, Search Console, 
 > **Payment handoff:** After fit and scope are confirmed, I reply with the normal invoice/payment instructions.
 >
 > **Methodology:** The same 20 buyer-intent prompts are run as a point-in-time diagnostic and reported per engine, with citation/source evidence where available. The audit is an observed snapshot, not a proprietary ranking promise or guaranteed forecast.
+>
+> **Want the protocol before buying?** [Read the AI Visibility Audit methodology](docs/ai-visibility-audit-methodology.md), including scope, engine coverage, interpretation limits, and what the audit does not claim.
 
 > **Prefer zero setup?** Try the hosted version at [digestseo.com](https://digestseo.com) — managed Cloudflare infra, no API keys to manage, multi-brand, scheduled refresh, web UI. Waitlist now open. [Join waitlist →](https://digestseo.com/#waitlist)
 

--- a/docs/ai-visibility-audit-methodology.md
+++ b/docs/ai-visibility-audit-methodology.md
@@ -1,0 +1,65 @@
+# AI Visibility Audit Methodology
+
+This page explains how the optional **EUR 99 one-time mcp-geo AI Visibility Audit** is run and how to interpret the result. The audit is a bounded, point-in-time diagnostic. It does not claim to predict future AI answers or guarantee rankings, citations, traffic, or commercial outcomes.
+
+## Scope
+
+Each paid audit uses the frozen offer scope:
+
+- one brand/domain;
+- up to three named competitors;
+- 20 buyer-intent prompts generated or agreed for the brand/category;
+- up to five mcp-geo-supported AI surfaces where the configured providers return usable results;
+- visibility/share-of-voice comparison;
+- citation/source evidence where returned by the engines;
+- prioritized content-gap and action recommendations grounded in the observed prompt results;
+- a concise delivered report.
+
+Target delivery is within two business days after usable brand and competitor input is received.
+
+## Measurement protocol
+
+1. **Define the prompt set.** Twenty buyer-intent prompts are generated or agreed for the brand and category. The prompt set used for the audit is kept consistent across the engines included in that audit so the per-engine comparison is based on the same questions.
+2. **Run the supported engines.** mcp-geo queries each configured AI surface included in the audit. An engine is only represented when its provider returns usable results; missing or failed provider responses are not presented as successful observations.
+3. **Record observed visibility.** The report distinguishes whether the brand appears in the returned answers and compares the same prompt set against the named competitors.
+4. **Record citation evidence.** Where an engine returns source or citation information, the audit records that evidence so the result is not only a top-line score.
+5. **Interpret the gaps.** Losing prompts, competitor appearances, and returned citation/source evidence are used to prioritize the content gaps and next actions in the report.
+
+## What the numbers mean
+
+The audit is a snapshot of the answers returned for the defined prompt set at the time it is run. AI answers can vary across time, models, interfaces, provider behavior, geography, and prompt wording. For that reason, the audit is designed for directional diagnosis and evidence review rather than treating one number as a permanent search ranking.
+
+The useful questions are:
+
+- Which buyer-intent prompts mention the brand?
+- Which named competitors appear on the same prompts?
+- How does visibility differ by engine?
+- Which sources or citations are returned where the engine exposes them?
+- Which observed gaps are actionable first?
+
+## What the audit does not claim
+
+The audit does **not** claim that:
+
+- one run represents every possible user or AI answer;
+- a visibility score is an official ranking published by an AI provider;
+- a cited brand is necessarily the brand an AI assistant would recommend;
+- a recommendation will cause a future ranking, citation, traffic, lead, or revenue increase;
+- all five supported surfaces will always return usable results.
+
+Any engine coverage limitations are stated in the delivered report rather than silently filled in or inferred.
+
+## Evidence and example output
+
+The report is built from mcp-geo's visibility, competitor-comparison, citation, and content-gap capabilities. You can inspect the output style before requesting the paid audit:
+
+- [View the existing sample report](./demo-report-full.png)
+- [See the mcp-geo tool definitions](../README.md#available-tools)
+
+The sample demonstrates reporting format and evidence depth. A paid audit is run for the buyer's own brand, prompt set, and named competitors.
+
+## Request and payment handoff
+
+To request the fixed-price audit, email `info@tomiseregi.si` with the brand/domain and up to three competitors. After fit and scope are confirmed, normal invoice/payment instructions are sent. An inquiry or invoice is not a completed purchase.
+
+The open-source mcp-geo package remains free under the MIT license; the paid value is the human-operated setup, execution, interpretation, and concise client-ready report.

--- a/tests/unit/revenue-readme.test.ts
+++ b/tests/unit/revenue-readme.test.ts
@@ -30,6 +30,10 @@ test('README exposes audit details and an attributable direct request path', () 
     readme,
     /> \*\*Methodology:\*\* The same 20 buyer-intent prompts are run as a point-in-time diagnostic and reported per engine/,
   );
+  assert.match(
+    readme,
+    /\[Read the AI Visibility Audit methodology\]\(docs\/ai-visibility-audit-methodology\.md\)/,
+  );
 
   const auditCta = readme.indexOf('> **Need a client-ready baseline without running the stack yourself?**');
   const waitlistCta = readme.indexOf('> **Prefer zero setup?**');


### PR DESCRIPTION
Publishes a dedicated AI Visibility Audit methodology page covering the fixed 20-prompt protocol, per-engine evidence, coverage limitations, interpretation boundaries, non-claims, sample output, and invoice handoff. Fresh buyer research shows opaque AI visibility scores are a trust objection; this adds durable proof without changing the frozen EUR 99 offer. Full local qualification passed: typecheck, 72/72 unit assertions, build, 2/2 stdio smoke.