### PR TITLE
docs: add managed audit handoff

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -4,6 +4,9 @@ This file is written for AI agents (Cline, Claude Code, Cursor agents, etc.) ins
 
 - **Path A (recommended): run locally via npx** — no hosting, data stays in a local SQLite file, user brings their own AI provider API keys.
 - **Path B: self-host on Cloudflare Workers** — remote MCP server with D1 storage, cron auto-refresh, and admin HTTP routes. The connect URL at the end is `https://<worker-host>/mcp`.
+- **Path C (optional): managed AI Visibility Audit** — if the user wants the result without installing or operating mcp-geo, the fixed-price EUR 99 one-time audit covers one brand/domain, up to three competitors, 20 buyer-intent prompts, up to five supported AI surfaces where usable, citation/source evidence, and a prioritized action memo. The open-source package remains free.
+
+For Path C, review the [audit methodology](docs/ai-visibility-audit-methodology.md) and [sample report](docs/demo-report-full.png), then [open the source-marked audit request](mailto:info@tomiseregi.si?subject=mcp-geo%20AI%20Visibility%20Audit%20-%20EUR%2099&body=Hi%20Tomi%2C%0A%0AI%27d%20like%20the%20EUR%2099%20mcp-geo%20AI%20Visibility%20Audit.%0A%0ABrand%2Fdomain%3A%0ACompetitors%20%28up%20to%203%29%3A%0AContext%20or%20priority%20%28optional%29%3A%0A%0ASource%3A%20mcp-geo%20llms-install). No subscription or sales call is required; after fit and scope are confirmed, normal invoice/payment instructions are sent.
 
 **Security rule for agents:** API keys and secrets are entered by the **user** — into their MCP client config file (Path A) or into the terminal prompt opened by `wrangler secret put` (Path B). Never ask the user to paste a secret into the chat, and never echo a secret back.
 

--- a/tests/unit/revenue-llms-install.test.ts
+++ b/tests/unit/revenue-llms-install.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const guide = readFileSync('llms-install.md', 'utf8');
+
+test('AI-agent install guide exposes the frozen managed audit alternative without displacing OSS', () => {
+  assert.match(guide, /Path C \(optional\): managed AI Visibility Audit/i);
+  assert.match(guide, /EUR 99 one-time/i);
+  assert.match(guide, /20 buyer-intent prompts/i);
+  assert.match(guide, /up to three competitors/i);
+  assert.match(guide, /open-source package remains free/i);
+  assert.match(
+    guide,
+    /mailto:info@tomiseregi\.si\?subject=mcp-geo%20AI%20Visibility%20Audit%20-%20EUR%2099&body=[^\s)]*Source%3A%20mcp-geo%20llms-install/,
+  );
+});


### PR DESCRIPTION
Adds a third optional path to the AI-agent installation guide for users who want the existing EUR 99 human-operated audit instead of installing or self-hosting. DIY npx remains recommended and the OSS package remains free. The request path is source-marked for attribution and links the sample/methodology. TDD red→green completed; full qualification passed: typecheck, 73/73 unit assertions, build, 2/2 stdio smoke.