### PR TITLE
feat(audit): link Worker root to audit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -567,21 +567,6 @@ const defaultHandler = {
     const auditResponse = handlePublicAudit(request);
     if (auditResponse) return auditResponse;
 
-    if (url.pathname === '/') {
-      if (request.method !== 'GET') {
-        return new Response('Method Not Allowed', {
-          status: 405,
-          headers: { Allow: 'GET' },
-        });
-      }
-      return new Response(
-        'digestseo-mcp — DigestSEO AI Visibility MCP server.\n' +
-          'Connect this URL as a custom MCP connector in Claude.ai:\n' +
-          `${url.origin}/mcp\n`,
-        { headers: { 'content-type': 'text/plain; charset=utf-8' } },
-      );
-    }
-
     if (url.pathname === '/healthz' && request.method === 'GET') {
       return new Response('ok', {
         headers: { 'content-type': 'text/plain; charset=utf-8' },

--- a/src/public-audit.ts
+++ b/src/public-audit.ts
@@ -26,6 +26,16 @@ const SITEMAP_BODY = `<?xml version="1.0" encoding="UTF-8"?>
   <url><loc>${AUDIT_URL}</loc></url>
 </urlset>`;
 
+function publicRootText(origin: string): string {
+  return (
+    'digestseo-mcp - DigestSEO AI Visibility MCP server.\n' +
+    'Connect this URL as a custom MCP connector in Claude.ai:\n' +
+    `${origin}/mcp\n\n` +
+    'EUR 99 AI Visibility Audit:\n' +
+    `${origin}/audit\n`
+  );
+}
+
 function auditHtml(origin: string): string {
   const mailto = `mailto:${AUDIT_EMAIL}?subject=${encodeURIComponent(AUDIT_SUBJECT)}&body=${encodeURIComponent(AUDIT_BODY)}`;
   const mcpUrl = `${origin}/mcp`;
@@ -210,7 +220,7 @@ function auditHtml(origin: string): string {
 
 export function handlePublicAudit(request: Request): Response | null {
   const url = new URL(request.url);
-  if (!['/audit', '/robots.txt', '/sitemap.xml'].includes(url.pathname)) {
+  if (!['/', '/audit', '/robots.txt', '/sitemap.xml'].includes(url.pathname)) {
     return null;
   }
 
@@ -223,6 +233,15 @@ export function handlePublicAudit(request: Request): Response | null {
 
   if (url.pathname === '/robots.txt') {
     return new Response(ROBOTS_BODY, {
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        'x-content-type-options': 'nosniff',
+      },
+    });
+  }
+
+  if (url.pathname === '/') {
+    return new Response(publicRootText(url.origin), {
       headers: {
         'content-type': 'text/plain; charset=utf-8',
         'x-content-type-options': 'nosniff',

--- a/tests/unit/public-audit.test.ts
+++ b/tests/unit/public-audit.test.ts
@@ -100,6 +100,23 @@ test('GET /robots.txt and /sitemap.xml expose the audit discovery URL', async ()
   );
 });
 
+test('GET / exposes both the MCP endpoint and the paid audit discovery path', async () => {
+  const { handlePublicAudit } = await loadAuditModule();
+  const response = handlePublicAudit(
+    new Request('https://geo-mcp.digestseo.com/'),
+  );
+
+  assert.ok(response);
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('content-type') ?? '', /text\/plain/);
+
+  const body = await response.text();
+  assert.match(body, /DigestSEO AI Visibility MCP server/);
+  assert.match(body, /https:\/\/geo-mcp\.digestseo\.com\/mcp/);
+  assert.match(body, /EUR 99 AI Visibility Audit/);
+  assert.match(body, /https:\/\/geo-mcp\.digestseo\.com\/audit/);
+});
+
 test('audit CTA opens a prefilled attributable request email', async () => {
   const { handlePublicAudit } = await loadAuditModule();
   const response = handlePublicAudit(
@@ -155,7 +172,7 @@ test('non-GET /audit requests are rejected without entering MCP or admin flows',
   assert.equal(response.headers.get('allow'), 'GET');
 });
 
-test('non-audit paths are ignored by the public audit router', async () => {
+test('non-public paths are ignored by the public audit router', async () => {
   const { handlePublicAudit } = await loadAuditModule();
   const response = handlePublicAudit(
     new Request('https://geo-mcp.digestseo.com/healthz'),


### PR DESCRIPTION
Adds the frozen EUR 99 audit URL to the public Worker root while preserving the MCP endpoint.\n\nTDD: new root discovery regression test failed before implementation and passes after.\n\nQualification: npm run typecheck; npm run test:unit (74/74); npm run build.