### PR TITLE
feat(audit): clarify invoice handoff

### DIFF
--- a/src/public-audit.ts
+++ b/src/public-audit.ts
@@ -131,6 +131,7 @@ function auditHtml(origin: string): string {
       <p id="request-status" class="status" role="status" aria-live="polite"></p>
     </form>
 
+    <p class="fine">After you email the request, Tomi will confirm fit and scope by email, then use the existing invoice and payment process. This page does not collect payment details.</p>
     <p class="fine">Email <a href="mailto:${AUDIT_EMAIL}">${AUDIT_EMAIL}</a> directly if your browser does not open an email app. No subscription, no sales call required. The audit does not guarantee rankings, citations, traffic, or commercial outcomes.</p>
     <a class="cta" href="${mailto}">Email the EUR 99 audit request</a>
     <noscript><p class="fine">JavaScript is optional. You can still <a href="${mailto}">email the prefilled audit request</a> directly.</p></noscript>

--- a/tests/unit/public-audit.test.ts
+++ b/tests/unit/public-audit.test.ts
@@ -33,6 +33,9 @@ test('GET /audit serves the frozen EUR 99 audit offer', async () => {
   assert.match(body, /point-in-time diagnostic/i);
   assert.match(body, /reported per engine/i);
   assert.match(body, /same 20 buyer-intent prompts/i);
+  assert.match(body, /confirm fit and scope by email/i);
+  assert.match(body, /existing invoice and payment process/i);
+  assert.match(body, /does not collect payment details/i);
   assert.doesNotMatch(body, /guaranteed (?:rank|traffic|citation)/i);
   assert.doesNotMatch(body, /GitHub Sponsors is active/i);
 });


### PR DESCRIPTION
Clarifies the existing frozen audit request flow: fit/scope confirmation happens by email, then the existing invoice/payment process is used; the audit page does not collect payment details. TDD regression coverage included.